### PR TITLE
fix: deleting an account no longer takes the transactions list down

### DIFF
--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -39,7 +39,15 @@ def transfer_rule_violation(
     return None
 
 
-class TransactionBase(BaseModel):
+class TransactionFields(BaseModel):
+    """A transaction's shape, without the rules that only make sense while
+    writing one. Reading goes through this: rows already in the database can
+    stop satisfying a write-time rule through no fault of their own — the
+    transfer_account_id FK is ON DELETE SET NULL, so deleting an account
+    leaves the transfers that pointed at it with no destination — and
+    refusing to serialize such a row would take the whole transactions list
+    down with it, leaving no way in the UI to find and delete the row."""
+
     account_id: int
     category_id: int | None = None
     transfer_account_id: int | None = None
@@ -56,6 +64,11 @@ class TransactionBase(BaseModel):
     @classmethod
     def _capitalize_description(cls, value: str) -> str:
         return capitalize_first_letter(value)
+
+
+class TransactionBase(TransactionFields):
+    """The write-side shape: the fields plus the invariants a new or edited
+    row has to satisfy."""
 
     @model_validator(mode="after")
     def _validate_type_specific_fields(self) -> "TransactionBase":
@@ -93,7 +106,7 @@ class TransactionUpdate(BaseModel):
         return capitalize_first_letter(value) if value is not None else None
 
 
-class TransactionRead(TransactionBase):
+class TransactionRead(TransactionFields):
     model_config = ConfigDict(from_attributes=True)
 
     id: int

--- a/backend/tests/test_transactions.py
+++ b/backend/tests/test_transactions.py
@@ -378,3 +378,26 @@ async def test_update_rejects_a_category_on_a_transfer(client: AsyncClient, acco
     )
 
     assert resp.status_code == 400
+
+
+async def test_a_transfer_whose_destination_account_was_deleted_can_still_be_listed(
+    client: AsyncClient, account_id
+):
+    """Deleting an account nulls transfer_account_id on the transfers that
+    pointed at it (the FK is ON DELETE SET NULL), leaving a row that create
+    would reject. Refusing to *serialize* such a row takes the whole
+    transactions list down with a 500 — and with the list gone there is no
+    way left in the UI to delete the row and recover. Reading has to stay
+    possible; only writing is guarded."""
+    other = (await client.post("/accounts", json={"name": "Savings", "type": "savings"})).json()
+    created = await client.post(
+        "/transactions", json=_txn(account_id, type="transfer", transfer_account_id=other["id"], category_id=None)
+    )
+    txn_id = created.json()["id"]
+    assert (await client.delete(f"/accounts/{other['id']}")).status_code == 204
+
+    listing = await client.get("/transactions")
+
+    assert listing.status_code == 200
+    assert txn_id in [item["id"] for item in listing.json()["items"]]
+    assert (await client.delete(f"/transactions/{txn_id}")).status_code == 204


### PR DESCRIPTION
Follow-up to #3, which closed the *write* path into this state. This closes the second way in — one that needs no API misuse at all.

## The bug

`transactions.transfer_account_id` is `ON DELETE SET NULL` (`models/transaction.py:19-21`). Deleting an account therefore nulls the destination of every transfer that pointed at it, leaving rows that create would reject. And because `TransactionRead` inherits `TransactionBase`'s validator, the rule meant for writing is applied when *reading*, so those rows can no longer be serialized:

1. create a transfer from Checking to Savings
2. delete the Savings account
3. open Transactions → `GET /api/transactions` returns 500

Permanently, and with the list gone there is no way in the UI to find and delete the affected rows. Only editing Postgres by hand recovers it.

Plain UI actions, no crafted requests: the app lets you delete an account, and doesn't warn that transfers point at it.

## The change

The fields move to `TransactionFields`, which reading uses. `TransactionBase` keeps the invariants for the write path, so #3's guarantees are untouched — new bad rows still can't be created.

The frontend already copes with a missing destination: `TransactionsTable` renders the transfer suffix only when `transfer_account_id` is set, and `TransactionFormModal` makes you pick a destination before it will save. So an orphaned row is now visible, editable and deletable instead of fatal.

Defence in depth: #3 stops new bad rows, this makes an existing one — from the FK, or written by any version before #3 — recoverable rather than terminal.

## Tests

One new test in `backend/tests/test_transactions.py`: a transfer whose destination account was deleted still lists, and can then be deleted. It fails on `main` and passes with this change. Full suite: `67 passed`.

## Not addressed here

Whether `ON DELETE SET NULL` is the right FK behaviour for `transfer_account_id` in the first place is a data-model decision, so I left it alone: the alternatives are refusing to delete an account that is still a transfer destination, or deleting those transfers with it. Both change what account deletion means, and per CONTRIBUTING that's a Discussion, not a drive-by PR. This change makes the current behaviour survivable either way.

`recurring_service.post_recurring` builds a `Transaction` directly rather than through the schema, so it can also write an orphaned transfer once the destination account is gone — same shape of problem, separate fix.