### PR TITLE
fix: force LF line endings so the web container starts on Windows checkouts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,31 @@
+# Line ending normalisation.
+#
+# On Windows, git with core.autocrlf=true rewrites text files to CRLF on
+# checkout. For files executed inside the Linux containers that is fatal: the
+# shebang becomes "#!/bin/sh\r", the kernel looks for an interpreter literally
+# named "/bin/sh\r", fails to find it, and the container dies with exit 127
+# ("not found"). Keep the working tree on LF regardless of host OS.
+* text=auto eol=lf
+
+# Explicit — everything Linux executes or parses.
+*.sh        text eol=lf
+*.envsh     text eol=lf
+Dockerfile  text eol=lf
+*.conf      text eol=lf
+*.yml       text eol=lf
+*.yaml      text eol=lf
+*.ini       text eol=lf
+*.mako      text eol=lf
+.env.example text eol=lf
+.dockerignore text eol=lf
+
+# Leave binary assets alone.
+*.png  binary
+*.jpg  binary
+*.jpeg binary
+*.gif  binary
+*.ico  binary
+*.webp binary
+*.woff binary
+*.woff2 binary
+*.pdf  binary

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -12,7 +12,12 @@ RUN apk add --no-cache openssl
 COPY --from=build /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY docker-entrypoint.d/20-basic-auth.sh /docker-entrypoint.d/20-basic-auth.sh
-RUN chmod +x /docker-entrypoint.d/20-basic-auth.sh \
+# sed strips any stray CR: cloned on Windows with core.autocrlf=true the
+# script arrives as CRLF, the kernel reads the shebang as "/bin/sh\r", and
+# nginx dies on boot with "not found" (exit 127). .gitattributes fixes this
+# at the repository level; this line covers checkouts that predate it.
+RUN sed -i 's/\r$//' /docker-entrypoint.d/20-basic-auth.sh \
+    && chmod +x /docker-entrypoint.d/20-basic-auth.sh \
     && touch /etc/nginx/basic-auth.conf
 
 EXPOSE 80


### PR DESCRIPTION
## Problem

`docker compose up -d --build` never produces a working `web` container on a Windows host. The container restart-loops with exit code 127:

```
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-basic-auth.sh
/docker-entrypoint.sh: line 31: /docker-entrypoint.d/20-basic-auth.sh: not found
```

The script is present and executable — the path is not what's missing. Git on Windows defaults to `core.autocrlf=true`, so `frontend/docker-entrypoint.d/20-basic-auth.sh` is rewritten to CRLF on checkout. The shebang then reads `#!/bin/sh\r`, the kernel looks for an interpreter literally named `/bin/sh\r`, and exec fails. nginx never starts.

`db` and `backend` come up healthy and all Alembic migrations run fine, which makes this easy to misread as a database or build problem rather than a line-ending one. The error message ("not found" for a file that plainly exists) gives no hint about the real cause.

`e2e/run.sh` is affected by the same checkout rewrite.

## Fix

**`.gitattributes` (new)** — pins LF for everything Linux executes or parses: `*.sh`, `*.envsh`, `Dockerfile`, `*.conf`, `*.yml`/`*.yaml`, `*.ini`, `*.mako`, `.env.example`, `.dockerignore`. Binary assets are marked `binary` so nothing touches them. This fixes the problem at the source: any fresh clone gets correct line endings on every OS.

**`frontend/Dockerfile`** — `sed -i 's/\r$//'` on the entrypoint script before `chmod +x`. `.gitattributes` only takes effect on checkout, so existing clones made before this change would still be broken; this one line makes the image build correctly regardless of what the host checkout looks like.

## Notes for the reviewer

- The repository's stored blobs were already LF — only the Windows working tree was affected. `git add --renormalize .` produces no changes beyond this PR's two files, so there is no line-ending churn in the diff.
- The `sed` in the Dockerfile is deliberately redundant with `.gitattributes`. Dropping it would leave anyone who cloned before this commit still broken until they re-clone or renormalise by hand. It costs one build step on an already-copied file.
- Existing clones can pick up the normalisation without a re-clone: `git rm --cached -r . && git reset --hard` (commit local work first).

## Verification

Tested on Windows 11, Docker Desktop 29.7.2, Compose v5.5.0, `core.autocrlf=true`:

- Before: `web` restart-loops on exit 127; `db` and `backend` healthy.
- After a full `docker compose up -d --build`: all three containers report `healthy`.
- `GET /` → 200 (SPA shell, intentionally unauthenticated per `nginx.conf`).
- `GET /api/health` → 200 with `auth_basic off`, so `HEALTHCHECK` still passes.
- `GET /api/accounts` → 401 without credentials, 200 with the configured basic-auth pair, 401 with a wrong password — the auth path in `20-basic-auth.sh` works once the script can actually execute.
