### PR TITLE
fix: respect the currency from .env on initialization

### DIFF
--- a/backend/alembic/versions/9f3a2d7c5e11_add_app_settings.py
+++ b/backend/alembic/versions/9f3a2d7c5e11_add_app_settings.py
@@ -5,6 +5,7 @@ Revises: 1152a14e9d55
 Create Date: 2026-08-16 12:00:00.000000
 
 """
+import os
 from typing import Sequence, Union
 
 from alembic import op
@@ -18,17 +19,32 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _default_currency() -> str:
+    """Read and validate the configured currency for a fresh database."""
+    currency = os.getenv("AURUM_DEFAULT_CURRENCY", "USD").strip().upper()
+    if len(currency) != 3 or not currency.isascii() or not currency.isalpha():
+        raise ValueError("AURUM_DEFAULT_CURRENCY must be a three-letter ISO 4217 code")
+    return currency
+
+
 def upgrade() -> None:
+    default_currency = _default_currency()
     op.create_table(
         'app_settings',
         sa.Column('id', sa.Integer(), nullable=False),
-        sa.Column('currency', sa.String(length=3), nullable=False, server_default='USD'),
+        sa.Column('currency', sa.String(length=3), nullable=False, server_default=default_currency),
         sa.PrimaryKeyConstraint('id'),
     )
     # Singleton row (id=1) — app boot's seed_default_app_settings() also
     # get-or-creates it, but seeding it here means it exists immediately
-    # after migrating, even before the app has started once.
-    op.execute("INSERT INTO app_settings (id, currency) VALUES (1, 'USD')")
+    # after migrating, even before the app has started once. Respect the
+    # configured default so non-USD installations are consistent from boot.
+    settings_table = sa.table(
+        'app_settings',
+        sa.column('id', sa.Integer()),
+        sa.column('currency', sa.String(length=3)),
+    )
+    op.bulk_insert(settings_table, [{'id': 1, 'currency': default_currency}])
 
 
 def downgrade() -> None:

--- a/backend/tests/test_app_settings_migration.py
+++ b/backend/tests/test_app_settings_migration.py
@@ -1,0 +1,44 @@
+"""Regression coverage for configurable currency on a fresh install."""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "alembic"
+    / "versions"
+    / "9f3a2d7c5e11_add_app_settings.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("app_settings_migration", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_default_currency_uses_environment(monkeypatch):
+    migration = _load_migration()
+    monkeypatch.setenv("AURUM_DEFAULT_CURRENCY", " rub ")
+
+    assert migration._default_currency() == "RUB"
+
+
+def test_default_currency_falls_back_to_usd(monkeypatch):
+    migration = _load_migration()
+    monkeypatch.delenv("AURUM_DEFAULT_CURRENCY", raising=False)
+
+    assert migration._default_currency() == "USD"
+
+
+@pytest.mark.parametrize("currency", ["RU", "RUB1", "РУБ"])
+def test_default_currency_rejects_invalid_codes(monkeypatch, currency):
+    migration = _load_migration()
+    monkeypatch.setenv("AURUM_DEFAULT_CURRENCY", currency)
+
+    with pytest.raises(ValueError, match="three-letter ISO 4217 code"):
+        migration._default_currency()


### PR DESCRIPTION
the alembic migration ran on every startup, setting `currency=USD` even if `AURUM_DEFAULT_CURRENCY` was set to something other than usd in .env

all tests are passed successfully